### PR TITLE
fix: pin claude-code-action to commit SHA (security: unpinned @eap action)

### DIFF
--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@eap
+        uses: anthropics\/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44  # v1
         with:
           mode: 'remote-agent'
           


### PR DESCRIPTION
## Summary
- Pins `anthropics/claude-code-action` from the mutable `@eap` tag to the immutable commit SHA `26ec041249acb0a944c0a47b6c0c13f05dbc5b44` in one workflow file
- Affected file: `.github/workflows/claude-dispatch.yml`

## Security Motivation
Using mutable tags (`@eap`) for GitHub Actions is a supply-chain risk — the tag can be moved to point at different, potentially malicious code at any time. Pinning to a specific commit SHA ensures the exact code that was audited continues to run.

## Test plan
- [ ] Verify the `claude-dispatch` workflow still triggers correctly on `repository_dispatch` events after merge
- [ ] Confirm the pinned SHA corresponds to the expected v1 release of the action