### PR TITLE
ci(security): add a manual trigger to Security Scans

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,10 @@
 name: Security Scans
 
 on:
+  # Manual trigger. Without it this workflow can only be re-run by pushing or waiting for the
+  # cron -- which is how it sat at `disabled_inactivity` from 2026-05-18 with nobody able to
+  # kick it, while its findings went stale against a lockfile that had moved on.
+  workflow_dispatch:
   push:
     branches: [main, dev]
   pull_request:


### PR DESCRIPTION
The Security Scans workflow had push/PR triggers and a weekly cron but no `workflow_dispatch`, so once GitHub marked it `disabled_inactivity` on 2026-05-18 there was no way to run it on demand.

Its 45 code-scanning findings are pinned to a `package-lock.json` that has since gone from 21 npm advisories to 0. Re-running it is the only way to refresh them, and re-running required this trigger.

The workflow is re-enabled; this makes it runnable.